### PR TITLE
hitSlop added to left icon

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -26,7 +26,16 @@ class NavBar extends React.Component {
   };
 
   renderLeft = () => {
-    const { back, left, leftStyle, leftIconColor, onLeftPress, theme, styles, leftHitSlop } = this.props;
+    const {
+      back,
+      left,
+      leftStyle,
+      leftIconColor,
+      onLeftPress,
+      theme,
+      styles,
+      leftHitSlop,
+    } = this.props;
 
     if (left) {
       return <View style={[styles.left, leftStyle]}>{left}</View>;
@@ -81,6 +90,7 @@ NavBar.defaultProps = {
   leftStyle: null,
   leftIconColor: null,
   onLeftPress: () => {},
+  leftHitSlop: null,
   right: null,
   rightStyle: null,
   style: null,
@@ -97,6 +107,7 @@ NavBar.propTypes = {
   leftStyle: PropTypes.any,
   leftIconColor: PropTypes.string,
   onLeftPress: PropTypes.func,
+  leftHitSlop: PropTypes.any,
   right: PropTypes.node,
   rightStyle: PropTypes.any,
   style: PropTypes.any,

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -26,7 +26,7 @@ class NavBar extends React.Component {
   };
 
   renderLeft = () => {
-    const { back, left, leftStyle, leftIconColor, onLeftPress, theme, styles } = this.props;
+    const { back, left, leftStyle, leftIconColor, onLeftPress, theme, styles, leftHitSlop } = this.props;
 
     if (left) {
       return <View style={[styles.left, leftStyle]}>{left}</View>;
@@ -34,7 +34,7 @@ class NavBar extends React.Component {
 
     return (
       <View style={[styles.left, leftStyle]}>
-        <TouchableOpacity onPress={() => onLeftPress && onLeftPress()}>
+        <TouchableOpacity onPress={() => onLeftPress && onLeftPress()} hitSlop={leftHitSlop}>
           <Icon
             family="Galio"
             color={leftIconColor || theme.COLORS.ICON}


### PR DESCRIPTION
this PR is related to: https://github.com/galio-org/galio/issues/91
It basically adds hitSlop support to left navbar icon. hitSlop is something recommended by react-native-community, helps developers to improve user experience. (https://facebook.github.io/react-native/docs/improvingux#make-tappable-areas-larger)
example usage:

```
<NavBar
    style={styles.navbar}
    right={this.renderRight()}
    leftHitSlop={{ top: 30, bottom: 30, left: 30, right: 30 }}
    leftStyle={{ paddingVertical: -12, flex: 0.3 }}
    leftIconColor={theme.COLORS.WHITE}
    titleStyle={styles.title}
    onLeftPress={this.handleLeftPress}
/>
```