### PR TITLE
add onRef prop to Input component for passing ref to rn text input

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -22,6 +22,7 @@ class Input extends React.Component {
 
   render() {
     const {
+      onRef,
       style,
       type,
       password,
@@ -96,6 +97,7 @@ class Input extends React.Component {
         <View style={inputViewStyles}>
           {left && !right && iconInstance}
           <TextInput
+            ref={onRef}
             style={inputStyles}
             keyboardType={type}
             secureTextEntry={isPassword}
@@ -135,6 +137,7 @@ Input.defaultProps = {
   iconSize: null,
   iconContent: null,
   theme: GalioTheme,
+  onRef: null,
 };
 
 Input.propTypes = {
@@ -160,6 +163,7 @@ Input.propTypes = {
   iconSize: PropTypes.number,
   iconContent: PropTypes.any,
   theme: PropTypes.any,
+  onRef: PropTypes.func,
 };
 
 const styles = theme =>


### PR DESCRIPTION
This would provide a solution for #74 by enabling accessing a ref on the react-native `TextInput` component that's the child of the Galio `Input` component via the proposed new `onRef` prop, while still enabling using the `ref` prop on the galio component itself.