### PR TITLE
Fix: Incorrect Implementation of View Pass Handler

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -50,7 +50,7 @@ function Input({
     styles.inputText,
     color && { color },
   ];
-  
+
   const iconInstance = icon ? (
     <Icon
       name={icon}
@@ -64,7 +64,7 @@ function Input({
     );
 
   const viewPassElement = password && viewPass && (
-    <TouchableOpacity style={{ marginLeft: 2 }} onPress={() => setIsPassword(password)}>
+    <TouchableOpacity style={{ marginLeft: 2 }} onPress={() => setIsPassword(!isPassword)}>
       <Icon
         size={iconSize || theme.SIZES.BASE * 1.0625}
         color={iconColor || theme.COLORS.BLACK}


### PR DESCRIPTION
The eye icon (view pass) handler for the `Input` element secure text entry is not implemented correctly. The eye icon toggle is supposed to toggle between the `secureTextEntry` values of the password text input property, but it does not do that right now. 

Current Bug:

Note `setIsPassword(password)` does not actually do anything since the password property is always true for password fields. 

```
const viewPassElement = password && viewPass && (
    <TouchableOpacity style={{ marginLeft: 2 }} onPress={() => setIsPassword(password)}>
      <Icon
        size={iconSize || theme.SIZES.BASE * 1.0625}
        color={iconColor || theme.COLORS.BLACK}
        name="eye"
        family="entypo"
      />
    </TouchableOpacity>
  );
``` 

Solution in PR: 

The solution is to toggle the `isPassword` flag instead. 

```
const viewPassElement = password && viewPass && (
    <TouchableOpacity style={{ marginLeft: 2 }} onPress={() => setIsPassword(!isPassword)}>
      <Icon
        size={iconSize || theme.SIZES.BASE * 1.0625}
        color={iconColor || theme.COLORS.BLACK}
        name="eye"
        family="entypo"
      />
    </TouchableOpacity>
  );
```