### PR TITLE
fix: remove duplicate style property from Text

### DIFF
--- a/src/Text.js
+++ b/src/Text.js
@@ -21,7 +21,6 @@ function Typography({
   italic,
   center,
   children,
-  style,
   styles,
   theme,
   ...rest


### PR DESCRIPTION
with typescript not working if the style declaration is duplicated.