### PR TITLE
Fix: Require cycle: on Components <-> Index File

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { ActivityIndicator, Dimensions, StyleSheet, TouchableOpacity, Text } from 'react-native';
 import PropTypes from 'prop-types';
 // galio components
-import { Icon } from './';
+import Icon from './Icon';
 import GalioTheme, { withGalio } from './theme';
 
 const { width } = Dimensions.get('window');

--- a/src/Card.js
+++ b/src/Card.js
@@ -2,8 +2,10 @@
 import React from 'react';
 import { Image, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
-
-import { Block, Icon, Text } from './';
+// galio components
+import Block from './Block';
+import Text from './Text';
+import Icon from './Icon';
 import GalioTheme, { withGalio } from './theme';
 
 function Card({

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -3,7 +3,8 @@ import React from 'react';
 import { View, TouchableOpacity, StyleSheet, Image } from 'react-native';
 import PropTypes from 'prop-types';
 // galio dependency
-import { Icon, Text } from './';
+import Icon from './Icon';
+import Text from './Text';
 import GalioTheme, { withGalio } from './theme';
 
 function Checkbox({

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -3,7 +3,9 @@ import { View, TouchableOpacity, StyleSheet, Dimensions } from 'react-native';
 import PropTypes from 'prop-types';
 
 // galio components
-import { Block, Text, Icon } from './';
+import Block from './Block';
+import Text from './Text';
+import Icon from './Icon';
 import GalioTheme, { withGalio } from './theme';
 
 const { height } = Dimensions.get('screen');

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 // G A L I O - D E P E N D E N C Y
-import { Text } from './';
+import Text from './Text';
 import GalioTheme, { withGalio } from './theme';
 
 function Radio({

--- a/src/Toast.js
+++ b/src/Toast.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Dimensions, StyleSheet, Animated, ViewPropTypes } from 'react-native';
 import PropTypes from 'prop-types';
 // galio components
-import { Text } from '.';
+import Text from './Text';
 import GalioTheme, { withGalio } from './theme';
 
 const { height } = Dimensions.get('screen');


### PR DESCRIPTION
Hello Guys. Nice work with this awesome components. 

PR has an import restructure for local components to fix the warning below.

`Require cycle: node_modules/galio-framework/src/index.js` happening on
- react-native: 0.62.2
- OS: Mac Catalina 10.15.5
- Galio Version: 0.6.3

## Screenshot
![Require Cycle Warning](https://user-images.githubusercontent.com/19955045/84579049-52f95c80-add3-11ea-89b0-ad79d6a6c9cc.png)
