### PR TITLE
remove `ViewPropTypes` as it has been deprecated

### DIFF
--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, Image, ViewPropTypes } from 'react-native';
+import { View, Text, StyleSheet, Image } from 'react-native';
 import PropTypes from 'prop-types';
 import { withGalio } from 'theme';
 
@@ -87,12 +87,14 @@ Avatar.propTypes = {
   backgroundColor: PropTypes.string,
   imageProps: PropTypes.object,
   imageStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.number]),
-  containerStyle: ViewPropTypes.style,
+  containerStyle: PropTypes.shape({
+    style: PropTypes.any,
+  }),
   styles: PropTypes.any,
   theme: PropTypes.any,
 };
 
-const styles = theme =>
+const styles = (theme) =>
   StyleSheet.create({
     labelContainerWithInset: {
       top: 1,

--- a/src/Toast.js
+++ b/src/Toast.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Dimensions, StyleSheet, Animated, ViewPropTypes } from 'react-native';
+import { Dimensions, StyleSheet, Animated } from 'react-native';
 import PropTypes from 'prop-types';
 // galio components
 import Text from './atomic/ions/Text';
@@ -20,8 +20,12 @@ class Toast extends Component {
       PropTypes.string,
     ]),
     round: PropTypes.bool,
-    style: ViewPropTypes.style,
-    textStyle: ViewPropTypes.style,
+    style: PropTypes.shape({
+      style: PropTypes.any,
+    }),
+    textStyle: PropTypes.shape({
+      style: PropTypes.any,
+    }),
     styles: PropTypes.any,
     theme: PropTypes.any,
   };
@@ -84,7 +88,7 @@ class Toast extends Component {
     }
   }
 
-  setVisibility = isShow => this.setState({ isShow });
+  setVisibility = (isShow) => this.setState({ isShow });
 
   getTopPosition = () => {
     const { positionIndicator, positionOffset } = this.props;
@@ -135,7 +139,7 @@ class Toast extends Component {
   }
 }
 
-const styles = theme =>
+const styles = (theme) =>
   StyleSheet.create({
     toast: {
       padding: theme.SIZES.BASE,


### PR DESCRIPTION
This is so it would work with `react-native-web`
and solving issue https://github.com/galio-org/galio/issues/234

https://github.com/necolas/react-native-web/releases/tag/0.12.0