### PR TITLE
Fix IconFamilyType

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,20 +11,19 @@ import {
 declare module 'galio-framework' {
   type IconFamilyType =
     | 'Galio'
-    | 'AntDesign'
-    | 'Entypo'
-    | 'EvilIcons'
-    | 'Feather'
-    | 'FontAwesome'
-    | 'FontAwesome5'
-    | 'Fontisto'
-    | 'Foundation'
-    | 'Ionicons'
-    | 'MaterialIcons'
-    | 'MaterialCommunityIcons'
-    | 'Octicons'
-    | 'Zocial'
-    | 'SimpleLineIcons';
+    | 'zocial'
+    | 'octicon'
+    | 'material'
+    | 'material-community'
+    | 'ionicon'
+    | 'foundation'
+    | 'evilicons'
+    | 'entypo'
+    | 'font-awesome'
+    | 'font-awesome-5'
+    | 'simple-line-icon'
+    | 'feather'
+    | 'antdesign';
 
   type BaseColorType = string;
 


### PR DESCRIPTION
Fixes the incorrect icon family types specified in TS declaration and updates them to actual accepted values.
Also removed invalid `feather` icon type. It is not accepted in `getIconType` helper.
Resolves #242 

