### PR TITLE
Typescript Typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -107,7 +107,7 @@ declare module 'galio-framework' {
     labelStyle?: TextStyle;
     onChange?: () => void;
   }
-  export class CheckBox extends React.Component<CheckBoxProps> {}
+  export class Checkbox extends React.Component<CheckBoxProps> {}
 
   export interface DeckSwiperProps extends BaseProps {
     style?: ViewStyle;


### PR DESCRIPTION
Fixed a capitalization typo for `Checkbox`.
It was being exported as `Checkbox` but typed as `CheckBox` in the index.d.ts and my IDE was complaining about this and I had to use a `@ts-ignore`