### PR TITLE
Upgrade @expo/vector-icons to ^15.0.2 for Expo SDK 54 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "postinstall": "opencollective-postinstall"
   },
   "dependencies": {
-    "@expo/vector-icons": "^14.1.0",
+    "@expo/vector-icons": "^15.0.2",
     "@react-native-vector-icons/fontisto": "^12.3.0",
     "opencollective-postinstall": "^2.0.3"
   },


### PR DESCRIPTION
This updates @expo/vector-icons to v15.0.2 to remove duplicate dependency issues
when using Galio with Expo SDK 54. This fixes compatibility with the latest Expo doctor checks.
